### PR TITLE
fix filename issue; add uploaded listener when file has been uploaded

### DIFF
--- a/lib/ali-oss-service.js
+++ b/lib/ali-oss-service.js
@@ -412,7 +412,7 @@ AliOssService.prototype.upload = function (req, res, options, cb) {
         var key;
         if (_.isString(self.options.bucket)) {
             bucket = self.options.bucket;
-            key = (options.container || req.params.container) + '/' + file;
+            key = (options.container || req.params.container) + '/' + filename;
         } else {
             bucket = options.container || req.params.container;
             key = file;
@@ -421,6 +421,10 @@ AliOssService.prototype.upload = function (req, res, options, cb) {
         var upload = self.ossStream.upload({
             Bucket: self.options.bucket || container,
             Key: key
+        });
+
+        upload.on('uploaded', function (details) {
+          cb(null, details);
         });
 
         file.pipe(upload);

--- a/lib/ali-oss-service.js
+++ b/lib/ali-oss-service.js
@@ -415,7 +415,7 @@ AliOssService.prototype.upload = function (req, res, options, cb) {
             key = (options.container || req.params.container) + '/' + filename;
         } else {
             bucket = options.container || req.params.container;
-            key = file;
+            key = filename;
         }
 
         var upload = self.ossStream.upload({


### PR DESCRIPTION
the key object is wrong when using file as the parameter meanwhile it's necessary to add uploaded listener when the ali oss upload file finish